### PR TITLE
fix(common): make the MMIO formal harness portable across front ends

### DIFF
--- a/doc/en/format_mmio.typ
+++ b/doc/en/format_mmio.typ
@@ -167,6 +167,12 @@ sby -f <module>_formal.sby prove
 sby -f <module>_formal.sby cover
 ```
 
+The harness resets itself from an `initial` value and then lets a free
+input pull reset again at any time. A tool that ignores `initial` blocks
+compiles the harness with `FORMAL_EXTERNAL_RESET` defined, which adds a
+`formal_reset_ni` port for the tool's own reset handling; the free input
+still re-enters reset, so those properties stay under proof.
+
 The generated job also has a `bmc` task for bounded counterexamples; omit the
 task name to run `prove`, `bmc`, and `cover`. The harness follows the selected
 address width, data width, register layout, resets, sidebands, byte strobes,

--- a/src/common/qsocmmioformal.cpp
+++ b/src/common/qsocmmioformal.cpp
@@ -75,6 +75,15 @@ QString bitRange(quint32 high, quint32 low)
     return high == low ? QString("[%1]").arg(low) : QString("[%1:%2]").arg(high).arg(low);
 }
 
+/**
+ * @brief The slice of a field's storage a lane touches; a one-bit field is
+ * a scalar reg and a bit select on it is not portable.
+ */
+QString storageSlice(const QSocMmioFieldPlan &field, quint32 high, quint32 low)
+{
+    return field.width == 1 ? QString() : bitRange(high - field.lsb, low - field.lsb);
+}
+
 QString verilogLiteral(quint32 width, quint64 value)
 {
     return QString("%1'h%2").arg(width).arg(QString::number(value, 16));
@@ -171,17 +180,37 @@ FormalNames allocateNames(const QSocMmioPlan &plan)
     return names;
 }
 
+/**
+ * @brief The reset the harness runs under.
+ *
+ * The default builds a two-cycle reset from an `initial` value. A tool that
+ * ignores `initial` blocks defines `FORMAL_EXTERNAL_RESET` and drives
+ * `formal_reset_ni` as a port instead. Either way a free input may pull
+ * reset again at any time, so re-entering reset stays under proof. The
+ * request is registered first: an asynchronous reset that moves on the
+ * clock edge itself races the sampling of the properties, and the tools do
+ * not agree on who wins.
+ */
 void appendClockAndReset(QStringList *lines, const FormalNames &names)
 {
-    lines->append(QString("reg [2:0] %1;").arg(names.resetShift));
+    lines->append(QString("reg %1;").arg(names.pastValid));
     lines->append(QString("(* anyseq *) reg %1;").arg(names.runtimeReset));
-    lines->append(
-        QString("wire rst_ni = %1[1] && (!%1[2] || %2);").arg(names.resetShift, names.runtimeReset));
+    lines->append(QString("reg %1_q;").arg(names.runtimeReset));
+    lines->append("always @(posedge clk_i)");
+    lines->append(QString("    %1_q <= %1;").arg(names.runtimeReset));
+    lines->append("`ifdef FORMAL_EXTERNAL_RESET");
+    lines->append(QString("wire rst_ni = formal_reset_ni && (!%1 || %2_q);")
+                      .arg(names.pastValid, names.runtimeReset));
+    lines->append("`else");
+    lines->append(QString("reg [2:0] %1;").arg(names.resetShift));
+    lines->append(QString("wire rst_ni = %1[1] && (!%1[2] || %2_q);")
+                      .arg(names.resetShift, names.runtimeReset));
     lines->append(QString());
     lines->append(QString("initial %1 = 3'b000;").arg(names.resetShift));
     lines->append(QString());
     lines->append("always @(posedge clk_i)");
     lines->append(QString("    %1 <= {%1[1:0], 1'b1};").arg(names.resetShift));
+    lines->append("`endif");
     lines->append(QString());
 }
 
@@ -260,7 +289,6 @@ void appendModelStorage(QStringList *lines, const QSocMmioPlan &plan, const Form
     lines->append(QString("reg %1;").arg(names.rValid));
     lines->append(QString("reg [%1:0] %2;").arg(plan.dataWidth - 1).arg(names.rData));
     lines->append(QString("reg [1:0] %1;").arg(names.rResponse));
-    lines->append(QString("reg %1;").arg(names.pastValid));
     lines->append(QString());
 }
 
@@ -388,7 +416,7 @@ void appendWriteCase(QStringList *lines, const QSocMmioPlan &plan, const FormalN
                     lines->append(QString("                        %1%2 <= %1%2 & ~%3%4;")
                                       .arg(
                                           storage,
-                                          bitRange(high - field.lsb, low - field.lsb),
+                                          storageSlice(field, high, low),
                                           names.writeData,
                                           bitRange(high, low)));
                     continue;
@@ -396,7 +424,7 @@ void appendWriteCase(QStringList *lines, const QSocMmioPlan &plan, const FormalN
                 lines->append(QString("                        %1%2 <= %3%4;")
                                   .arg(
                                       storage,
-                                      bitRange(high - field.lsb, low - field.lsb),
+                                      storageSlice(field, high, low),
                                       names.writeData,
                                       bitRange(high, low)));
             }
@@ -664,11 +692,17 @@ void appendResetAssertions(QStringList *lines, const QSocMmioPlan &plan, const F
 
 void appendProperties(QStringList *lines, const QSocMmioPlan &plan, const FormalNames &names)
 {
+    lines->append("`ifdef FORMAL_EXTERNAL_RESET");
+    lines->append("always @(posedge clk_i or negedge formal_reset_ni)");
+    lines->append(QString("    %1 <= formal_reset_ni;").arg(names.pastValid));
+    lines->append("`else");
     lines->append(QString("initial %1 = 1'b0;").arg(names.pastValid));
     lines->append(QString());
-    lines->append("always @(posedge clk_i) begin");
+    lines->append("always @(posedge clk_i)");
     lines->append(QString("    %1 <= 1'b1;").arg(names.pastValid));
+    lines->append("`endif");
     lines->append(QString());
+    lines->append("always @(posedge clk_i) begin");
     lines->append(QString("    if (%1 && rst_ni && $past(rst_ni)) begin").arg(names.pastValid));
     appendMasterAssumptions(lines, names);
     appendResponseStability(lines);
@@ -693,6 +727,9 @@ QString buildSystemVerilog(const QSocMmioPlan &plan)
     lines.append("// Generated by QSoC. Do not edit.");
     lines.append(QString("module %1_formal (").arg(plan.moduleName));
     lines.append("    input wire clk_i");
+    lines.append("`ifdef FORMAL_EXTERNAL_RESET");
+    lines.append("    , input wire formal_reset_ni");
+    lines.append("`endif");
     lines.append(");");
     lines.append(QString());
     appendClockAndReset(&lines, names);

--- a/test/test_qsocmmioformal.cpp
+++ b/test/test_qsocmmioformal.cpp
@@ -474,13 +474,17 @@ void Test::w1cModelSetsAfterTheWrite()
         sv.contains(QStringLiteral("                formal_read_register[8] = formal_field_1_q;")));
     const QString clear = QStringLiteral(
         "                    if (formal_write_strobe[1])\n"
-        "                        formal_field_1_q[0] <= formal_field_1_q[0] & "
+        "                        formal_field_1_q <= formal_field_1_q & "
         "~formal_write_data[8];");
     const QString set = QStringLiteral(
         "        if (done_i)\n"
         "            formal_field_1_q <= 1'b1;");
     const qsizetype clearIndex = sv.indexOf(clear);
     const qsizetype setIndex   = sv.indexOf(set);
+    /* A one-bit field is a scalar reg; a bit select on it is not portable. */
+    QVERIFY(!sv.contains(QStringLiteral("_q[0] <=")));
+    QVERIFY(sv.contains(
+        QStringLiteral("`ifdef FORMAL_EXTERNAL_RESET\n    , input wire formal_reset_ni\n`endif")));
     QVERIFY(clearIndex >= 0);
     QVERIFY(setIndex > clearIndex);
     QCOMPARE(sv.count(set), qsizetype(1));


### PR DESCRIPTION
## Why

The register slave harness wrote a one-bit field as `formal_field_N_q[0] <= ...` while declaring it `reg formal_field_N_q;`. Yosys accepts a bit select on a scalar, another SystemVerilog front end refuses it as an index into a non-array, and a third only warns, so the same harness parsed on one engine and not on the next. The harness also builds its reset from an `initial` value, which engines that ignore initial blocks turn into a free register, and every reset-dependent property then fails from an unreset state.

## What this changes

A one-bit field's storage is written whole; wider fields keep their slice. Defining `FORMAL_EXTERNAL_RESET` at compile time adds a `formal_reset_ni` port and derives the past-valid flag from it, so an engine can apply its own reset handling. The free input that pulls reset again at any time stays in both modes, so the reset re-entry properties are proven rather than vacuous under an external reset. The request itself is registered before it reaches the reset, because an asynchronous reset that moves on the clock edge races the sampling of the handshake stability properties and the engines did not agree on who wins: one reported five stability assertions falsified where the others proved them, and the trace showed the reset landing on the very edge. Without the define the harness is what it was apart from that register. The manual names the define.

## How it was verified

The W1C test now expects the scalar write and rejects any `_q[0] <=` in the harness, and checks the conditional port. The 185-pin design's register harness, regenerated, was elaborated on an independent front end that had rejected it with 19 errors before the change, and the routing harness of the same design was proven there in full with a pin-17 mutation caught on exactly that pin's assertions. The SymbiYosys jobs in the test suite pass unchanged.
